### PR TITLE
Extract and persist full FMD2 metadata during downloads

### DIFF
--- a/paperbox/src/downloads/manager.ts
+++ b/paperbox/src/downloads/manager.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
-import { runModule } from "../lua/engine";
+import { runModule, type MangaInfo } from "../lua/engine";
 import { getScript, getScriptByName } from "../lua/scripts";
 import { getMangaDir, scan } from "../scanner";
 
@@ -189,18 +189,7 @@ async function processTask(task: DownloadTask): Promise<void> {
     const infoResult = await runModule(script.path, "GetInfo", {
       url: task.mangaUrl,
     });
-    const info = infoResult.mangaInfo;
-    const meta: Record<string, any> = {
-      title: info.title || task.mangaTitle,
-      author: info.authors || "",
-      artist: info.artists || "",
-      description: info.summary || "",
-      tags: info.genres ? info.genres.split(",").map((g: string) => g.trim()).filter(Boolean) : [],
-      status: info.status || "",
-      cover: info.coverLink || "",
-    };
-    await writeFile(join(seriesDir, "manga.json"), JSON.stringify(meta, null, 2));
-    console.log(`[download]   Saved metadata for: ${meta.title}`);
+    await saveMetadata(seriesDir, infoResult.mangaInfo, task.mangaTitle, task.mangaUrl);
   } catch (e: any) {
     console.error(`[download]   Failed to fetch metadata: ${e?.message}`);
     // Continue without metadata - download can still proceed
@@ -319,6 +308,68 @@ async function downloadPageWithRetry(
     }
   }
   return false;
+}
+
+/**
+ * Save full FMD2 metadata for a manga series: cover image, manga.json, and source-info.json.
+ */
+export async function saveMetadata(
+  seriesDir: string,
+  info: MangaInfo,
+  fallbackTitle: string,
+  sourceUrl: string,
+): Promise<void> {
+  // Download cover image
+  let coverFilename = "";
+  if (info.coverLink) {
+    try {
+      const coverResp = await fetch(info.coverLink, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+          Referer: sourceUrl,
+        },
+      });
+      if (coverResp.ok) {
+        const ext = getExtFromUrl(info.coverLink);
+        coverFilename = `cover${ext}`;
+        const buffer = await coverResp.arrayBuffer();
+        await Bun.write(join(seriesDir, coverFilename), buffer);
+        console.log(`[metadata]   Saved cover: ${coverFilename}`);
+      }
+    } catch (e: any) {
+      console.error(`[metadata]   Failed to download cover: ${e?.message}`);
+    }
+  }
+
+  // Save manga.json (library metadata)
+  const meta: Record<string, any> = {
+    title: info.title || fallbackTitle,
+    author: info.authors || "",
+    artist: info.artists || "",
+    description: info.summary || "",
+    link: info.link || sourceUrl || "",
+    tags: info.genres ? info.genres.split(",").map((g: string) => g.trim()).filter(Boolean) : [],
+    status: info.status || "",
+    cover: coverFilename || info.coverLink || "",
+  };
+  await writeFile(join(seriesDir, "manga.json"), JSON.stringify(meta, null, 2));
+  console.log(`[metadata]   Saved metadata for: ${meta.title}`);
+
+  // Save source-info.json (full raw FMD2 output)
+  const sourceInfo = {
+    title: info.title,
+    link: info.link,
+    coverLink: info.coverLink,
+    authors: info.authors,
+    artists: info.artists,
+    genres: info.genres,
+    summary: info.summary,
+    status: info.status,
+    chapterNames: info.chapterNames,
+    chapterLinks: info.chapterLinks,
+  };
+  await writeFile(join(seriesDir, "source-info.json"), JSON.stringify(sourceInfo, null, 2));
+  console.log(`[metadata]   Saved source-info.json`);
 }
 
 function sanitizePath(name: string): string {

--- a/paperbox/src/routes/manga.ts
+++ b/paperbox/src/routes/manga.ts
@@ -1,5 +1,9 @@
 import { Elysia, t } from "elysia";
+import { join } from "path";
 import { getMangaList, getManga, scan, getLastScan, getMangaDir } from "../scanner";
+import { runModule } from "../lua/engine";
+import { getScript } from "../lua/scripts";
+import { saveMetadata } from "../downloads/manager";
 
 export const mangaRoutes = new Elysia({ prefix: "/api" })
   .get("/manga", ({ query }) => {
@@ -35,6 +39,53 @@ export const mangaRoutes = new Elysia({ prefix: "/api" })
     return manga;
   }, {
     params: t.Object({ id: t.String() }),
+  })
+  .post("/manga/:id/refresh", async ({ params, body, set }) => {
+    const manga = getManga(params.id);
+    if (!manga) {
+      set.status = 404;
+      return { error: "Manga not found" };
+    }
+
+    const script = getScript(body.sourceId);
+    if (!script) {
+      set.status = 404;
+      return { error: "Script not found" };
+    }
+
+    try {
+      const infoResult = await runModule(script.path, "GetInfo", {
+        url: body.url,
+      });
+
+      // Find the original folder name on disk
+      const { readdir } = await import("fs/promises");
+      const mangaDir = getMangaDir();
+      const entries = await readdir(mangaDir);
+      const slugify = (name: string) =>
+        name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const folderName = entries.find((e) => slugify(e) === params.id);
+      if (!folderName) {
+        set.status = 404;
+        return { error: "Manga folder not found on disk" };
+      }
+
+      const seriesDir = join(mangaDir, folderName);
+      await saveMetadata(seriesDir, infoResult.mangaInfo, manga.title, body.url);
+      await scan();
+
+      return { ok: true, manga: getManga(params.id) };
+    } catch (e: any) {
+      console.error(`[refresh] Failed:`, e);
+      set.status = 500;
+      return { error: e?.message || "Refresh failed" };
+    }
+  }, {
+    params: t.Object({ id: t.String() }),
+    body: t.Object({
+      url: t.String(),
+      sourceId: t.String(),
+    }),
   })
   .post("/scan", async () => {
     await scan();

--- a/paperbox/src/routes/paperback.ts
+++ b/paperbox/src/routes/paperback.ts
@@ -216,7 +216,7 @@ function toSuwayomiManga(manga: MangaDetail, numId: number) {
       displayName: "Paperbox",
     },
     meta: {},
-    realUrl: "",
+    realUrl: manga.meta.link || "",
     lastFetchedAt: NOW_SECS,
     chaptersLastFetchedAt: NOW_SECS,
     updateStrategy: "ALWAYS_UPDATE",

--- a/paperbox/src/types.ts
+++ b/paperbox/src/types.ts
@@ -4,6 +4,7 @@ export interface MangaMeta {
   artist?: string;
   description?: string;
   cover?: string;
+  link?: string;
   tags?: string[];
   status?: "ongoing" | "completed" | "hiatus" | "cancelled";
 }


### PR DESCRIPTION
- Download cover images to disk as cover.{ext} instead of just saving the URL
- Save complete raw FMD2 output as source-info.json alongside manga.json
- Add source URL (link) to manga.json and MangaMeta type
- Add POST /api/manga/:id/refresh endpoint to re-fetch metadata for existing manga
- Populate Suwayomi realUrl with source link for Paperback compatibility
- Extract shared saveMetadata() helper to avoid duplicating persistence logic

https://claude.ai/code/session_01CJo2qybmzVKsQrg5BUTpdE